### PR TITLE
test bubbling of errors in Duplex mode

### DIFF
--- a/test/multipipe.js
+++ b/test/multipipe.js
@@ -44,6 +44,8 @@ describe('pipe(a, b, c)', function(){
     var err = new Error;
     var i = 0;
     
+    assert(stream instanceof Stream.Duplex)
+    
     stream.on('error', function(_err){
       i++;
       assert.equal(_err, err);


### PR DESCRIPTION
I spent some time digging on why your modified test case goes through.

This modification breaks it. In fact, with you setup (Readable, Transform, Writable) you are not getting a Duplex.

try with (Transform, Transform, Transform) and you will see the 5 errors bubbling.
