### PR TITLE
default { bubbleErrors: true }. closes #47

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ const { PassThrough, Readable } = require('stream')
  */
 
 const defaultOpts = {
-  bubbleErrors: false,
+  bubbleErrors: true,
   objectMode: true
 }
 


### PR DESCRIPTION
Let's see what CI says. Locally tests still pass, but it would also be nice to add a tests that demonstrates the previous problem mentioned in #47.